### PR TITLE
Modifies `require` to match the name of a contract

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,4 +1,4 @@
-var Migrations = artifacts.require("./Migrations.sol");
+const Migrations = artifacts.require("Migrations");
 
 module.exports = function(deployer) {
   deployer.deploy(Migrations);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
-var ConvertLib = artifacts.require("ConvertLib");
-var MetaCoin = artifacts.require("MetaCoin");
+const ConvertLib = artifacts.require("ConvertLib");
+const MetaCoin = artifacts.require("MetaCoin");
 
 module.exports = function(deployer) {
   deployer.deploy(ConvertLib);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
-var ConvertLib = artifacts.require("./ConvertLib.sol");
-var MetaCoin = artifacts.require("./MetaCoin.sol");
+var ConvertLib = artifacts.require("ConvertLib");
+var MetaCoin = artifacts.require("MetaCoin");
 
 module.exports = function(deployer) {
   deployer.deploy(ConvertLib);

--- a/test/metacoin.js
+++ b/test/metacoin.js
@@ -1,4 +1,4 @@
-var MetaCoin = artifacts.require("./MetaCoin.sol");
+const MetaCoin = artifacts.require("MetaCoin");
 
 contract('MetaCoin', function(accounts) {
   it("should put 10000 MetaCoin in the first account", function() {


### PR DESCRIPTION
* Do not pass the name of the source file because files can contain
  more than one contract