### PR TITLE
Invalid syntax on version 0.4.18

### DIFF
--- a/contracts/MetaCoin.sol
+++ b/contracts/MetaCoin.sol
@@ -12,7 +12,7 @@ contract MetaCoin {
 
 	event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
-	constructor() public {
+	function MetaCoin() public {
 		balances[tx.origin] = 10000;
 	}
 
@@ -20,7 +20,7 @@ contract MetaCoin {
 		if (balances[msg.sender] < amount) return false;
 		balances[msg.sender] -= amount;
 		balances[receiver] += amount;
-		emit Transfer(msg.sender, receiver, amount);
+		Transfer(msg.sender, receiver, amount);
 		return true;
 	}
 


### PR DESCRIPTION
Tried to compile and had to change the constructor and the emit because they apparently are not valid syntax on Solidity 0.4.18, either had to change the version or the syntax used in those 2 lines