### PR TITLE
Remove .placeholder files and add Solidity syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/contracts/.placeholder
+++ b/contracts/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/test/.placeholder
+++ b/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.


### PR DESCRIPTION
 * Remove `contracts/.placeholder` as it's no longer needed. It was originally added so that the empty directory would get saved to git. That directory is no longer empty so removing `contracts/.placeholder` won't cause any problems.
* Add `.gitattributes` so that Github shows Solidity syntax highlighting. I learned about this in [Open Zeppelin's repo](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.gitattributes). You can see a [working example here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol)