### PR TITLE
remove .call for view functions

### DIFF
--- a/test/metacoin.js
+++ b/test/metacoin.js
@@ -3,17 +3,19 @@ const MetaCoin = artifacts.require("MetaCoin");
 contract('MetaCoin', (accounts) => {
   it('should put 10000 MetaCoin in the first account', async () => {
     const metaCoinInstance = await MetaCoin.deployed();
-    const balance = await metaCoinInstance.getBalance.call(accounts[0]);
+    const balance = await metaCoinInstance.getBalance(accounts[0]);
 
     assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
   });
+
   it('should call a function that depends on a linked library', async () => {
     const metaCoinInstance = await MetaCoin.deployed();
-    const metaCoinBalance = (await metaCoinInstance.getBalance.call(accounts[0])).toNumber();
-    const metaCoinEthBalance = (await metaCoinInstance.getBalanceInEth.call(accounts[0])).toNumber();
+    const metaCoinBalance = (await metaCoinInstance.getBalance(accounts[0])).toNumber();
+    const metaCoinEthBalance = (await metaCoinInstance.getBalanceInEth(accounts[0])).toNumber();
 
     assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, 'Library function returned unexpected function, linkage may be broken');
   });
+
   it('should send coin correctly', async () => {
     const metaCoinInstance = await MetaCoin.deployed();
 
@@ -22,16 +24,16 @@ contract('MetaCoin', (accounts) => {
     const accountTwo = accounts[1];
 
     // Get initial balances of first and second account.
-    const accountOneStartingBalance = (await metaCoinInstance.getBalance.call(accountOne)).toNumber();
-    const accountTwoStartingBalance = (await metaCoinInstance.getBalance.call(accountTwo)).toNumber();
+    const accountOneStartingBalance = (await metaCoinInstance.getBalance(accountOne)).toNumber();
+    const accountTwoStartingBalance = (await metaCoinInstance.getBalance(accountTwo)).toNumber();
 
     // Make transaction from first account to second.
     const amount = 10;
     await metaCoinInstance.sendCoin(accountTwo, amount, { from: accountOne });
 
     // Get balances of first and second account after the transactions.
-    const accountOneEndingBalance = (await metaCoinInstance.getBalance.call(accountOne)).toNumber();
-    const accountTwoEndingBalance = (await metaCoinInstance.getBalance.call(accountTwo)).toNumber();
+    const accountOneEndingBalance = (await metaCoinInstance.getBalance(accountOne)).toNumber();
+    const accountTwoEndingBalance = (await metaCoinInstance.getBalance(accountTwo)).toNumber();
 
 
     assert.equal(accountOneEndingBalance, accountOneStartingBalance - amount, "Amount wasn't correctly taken from the sender");


### PR DESCRIPTION
Not sure if this is an artifact from old Truffle versions, but `view` function shouldn't have the `.call` in my opinion.