### PR TITLE
Add Truffle DB settings

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -29,7 +29,7 @@ module.exports = {
     adapter: {
       name: "sqlite",
       settings: {
-        // You may also choose a differnt directory name
+        // You may also choose a different directory name
         // Note. it will alwasy be relative to Project Root
         // (the same folder where this file is located.
         directory: ".truffle-db"  

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,6 +16,23 @@ module.exports = {
   //    port: 7545,
   //    network_id: "*"
   //  }
-  //}
+  //},
+
   //
+  db: {
+    // Truffle-DB is disabled by default. 
+    enabled: false
+
+    // You can also use a local db storage adapter by uncommenting this section
+    //
+    //, adapter: {
+    //   name: "sqlite",
+    //   settings: {
+    //     // You may also choose a differnt directory name
+    //     // Note. it will alwasy be relative to Project Root
+    //     // (the same folder where this file is located.
+    //     directory: ".truffle-db"  
+    //   }
+    // }                             
+  }
 };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -31,7 +31,7 @@ module.exports = {
       settings: {
         // You may also choose a different directory name
         // Note. it will always be relative to the Project root
-        // (the same folder where this file is located.
+        // (the same folder where this file is located.)
         directory: ".truffle-db"  
       }
     }                             

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -21,7 +21,8 @@ module.exports = {
   //
   db: {
     // Truffle-DB is disabled by default. 
-    enabled: false
+    enabled: false,
+    host: "127.0.0.1"
 
     // You can also use a local db storage adapter by uncommenting this section
     //

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -30,7 +30,7 @@ module.exports = {
       name: "sqlite",
       settings: {
         // You may also choose a different directory name
-        // Note. it will alwasy be relative to Project Root
+        // Note. it will always be relative to the Project root
         // (the same folder where this file is located.
         directory: ".truffle-db"  
       }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -29,10 +29,11 @@ module.exports = {
     adapter: {
       name: "sqlite",
       settings: {
-        // You may also choose a different directory name
-        // Note. it will always be relative to the Project root
-        // (the same folder where this file is located.)
-        directory: ".truffle-db"  
+        // You may specify a directory name that is an absolute path, or one
+        // relative to the Project Root, the same folder where this file is
+        // located. For example, the following defines a `.db` directory in
+        // Project Root.
+        directory: ".db"  
       }
     }                             
   }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -17,23 +17,25 @@ module.exports = {
   //    network_id: "*"
   //  }
   //},
-
-  //db: {
-  //  // Truffle-DB is disabled by default. 
-  //  enabled: true,
-  //  host: "127.0.0.1",
-
-  //  // You can also use a local db storage adapter by uncommenting this section
-  //  //
-  //  adapter: {
-  //    name: "sqlite",
-  //    settings: {
-  //      // You may specify a directory name that is an absolute path, or one
-  //      // relative to the Project Root, the same folder where this file is
-  //      // located. For example, the following defines a `.db` directory in
-  //      // Project Root.
-  //      directory: ".db"  
-  //    }
-  //  }                             
-  //}
+  //
+  // Truffle DB is currently disabled by default; to enable it, change enabled:
+  // false to enabled: true. The default storage location can also be
+  // overridden by specifying the adapter settings, as shown in the commented code below.
+  //
+  // NOTE: It is not possible to migrate your contracts to truffle DB and you should
+  // make a backup of your artifacts to a safe location before enabling this feature.
+  //
+  // After you backed up your artifacts you can utilize db by running migrate as follows: 
+  // $ truffle migrate --reset --compile-all
+  //
+  // db: {
+    // enabled: false,
+    // host: "127.0.0.1",
+    // adapter: {
+    //   name: "sqlite",
+    //   settings: {
+    //     directory: ".db"
+    //   }
+    // }
+  // }
 };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -18,23 +18,22 @@ module.exports = {
   //  }
   //},
 
-  //
-  db: {
-    // Truffle-DB is disabled by default. 
-    enabled: false,
-    host: "127.0.0.1",
+  //db: {
+  //  // Truffle-DB is disabled by default. 
+  //  enabled: true,
+  //  host: "127.0.0.1",
 
-    // You can also use a local db storage adapter by uncommenting this section
-    //
-    adapter: {
-      name: "sqlite",
-      settings: {
-        // You may specify a directory name that is an absolute path, or one
-        // relative to the Project Root, the same folder where this file is
-        // located. For example, the following defines a `.db` directory in
-        // Project Root.
-        directory: ".db"  
-      }
-    }                             
-  }
+  //  // You can also use a local db storage adapter by uncommenting this section
+  //  //
+  //  adapter: {
+  //    name: "sqlite",
+  //    settings: {
+  //      // You may specify a directory name that is an absolute path, or one
+  //      // relative to the Project Root, the same folder where this file is
+  //      // located. For example, the following defines a `.db` directory in
+  //      // Project Root.
+  //      directory: ".db"  
+  //    }
+  //  }                             
+  //}
 };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -22,18 +22,18 @@ module.exports = {
   db: {
     // Truffle-DB is disabled by default. 
     enabled: false,
-    host: "127.0.0.1"
+    host: "127.0.0.1",
 
     // You can also use a local db storage adapter by uncommenting this section
     //
-    //, adapter: {
-    //   name: "sqlite",
-    //   settings: {
-    //     // You may also choose a differnt directory name
-    //     // Note. it will alwasy be relative to Project Root
-    //     // (the same folder where this file is located.
-    //     directory: ".truffle-db"  
-    //   }
-    // }                             
+    adapter: {
+      name: "sqlite",
+      settings: {
+        // You may also choose a differnt directory name
+        // Note. it will alwasy be relative to Project Root
+        // (the same folder where this file is located.
+        directory: ".truffle-db"  
+      }
+    }                             
   }
 };


### PR DESCRIPTION
This PR adds truffle db settings in truffle-config.

## testing

1. Unbox this branch
    ```console
    truffle unbox metacoin#add-db mc-db
    cd mc-db
    ```
 1. verify that the box works by default. 
    ```
    truffle test
    truffle migrate 
    ```   
 1. enable truffle db, clean build folder and migrate
    ```
    rm -rf build
    truffle develop
    migrate 
    ```
1. Start db's graphql query server
    ```
    truffle db serve
    ```
1. browse to http://localhost:4444 and run the following query
    ```
    {
     projects {
       id
       networks {
         name
         networkId
       }
       directory
       contracts {
         name  
       }
     }
    }
    ```
Expected Query results - Your result should have the following structure (ids and file paths will differ):
```
{
  "data": {
    "projects": [
      {
        "id": "0x6a9576e99403732df097a2e8f3ea33119bc936de1ddf5684ccb1a934cc1b4db5",
        "networks": [
          {
            "name": "develop",
            "networkId": 5777
          }
        ],
        "directory": "/home/amal/work/reproduce/2021/08/05/mc-db",
        "contracts": [
          {
            "name": "Migrations"
          },
          {
            "name": "MetaCoin"
          },
          {
            "name": "ConvertLib"
          }
        ]
      }
    ]
  }
}
```

   
