### PR TITLE
Update url in comments in truffle-config.js

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,9 +1,9 @@
 module.exports = {
   // Uncommenting the defaults below
   // provides for an easier quick-start with Ganache.
-  // You can also follow this format for other networks;
-  // see <https://trufflesuite.com/docs/truffle/reference/configuration>
-  // for more details on how to specify configuration options!
+  // You can also follow this format for other networks.
+  // See details at: https://trufflesuite.com/docs/truffle/reference/configuration
+  // on how to specify configuration options!
   //
   //networks: {
   //  development: {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,8 +1,8 @@
 module.exports = {
-  // Uncommenting the defaults below 
+  // Uncommenting the defaults below
   // provides for an easier quick-start with Ganache.
   // You can also follow this format for other networks;
-  // see <http://truffleframework.com/docs/advanced/configuration>
+  // see <https://trufflesuite.com/docs/truffle/reference/configuration>
   // for more details on how to specify configuration options!
   //
   //networks: {
@@ -25,7 +25,7 @@ module.exports = {
   // NOTE: It is not possible to migrate your contracts to truffle DB and you should
   // make a backup of your artifacts to a safe location before enabling this feature.
   //
-  // After you backed up your artifacts you can utilize db by running migrate as follows: 
+  // After you backed up your artifacts you can utilize db by running migrate as follows:
   // $ truffle migrate --reset --compile-all
   //
   // db: {


### PR DESCRIPTION
### ISSUE
`truffle-config.js` has an outdated url in the comments.

### SOLUTION
The outdated url is replaced with the new url pointing to the required documentation.