### PR TITLE
command out HDWalletProvider & network

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -21,8 +21,8 @@
 // require('dotenv').config();
 // const mnemonic = process.env["MNEMONIC"];
 // const infuraProjectId = process.env["INFURA_PROJECT_ID"];
- 
-const HDWalletProvider = require('@truffle/hdwallet-provider');
+
+// const HDWalletProvider = require('@truffle/hdwallet-provider');
 
 module.exports = {
   /**
@@ -47,11 +47,11 @@ module.exports = {
 //      port: 8545,            // Standard Ethereum port (default: none)
 //      network_id: "*",       // Any network (default: none)
 //     },
-    goerli: {
-      provider: () => new HDWalletProvider(mnemonic, `https://goerli.infura.io/v3/${infuraProjectId}`),
-      network_id: 5,       // Goerli's id
-      chain_id: 5
-    }
+    // goerli: {
+    //   provider: () => new HDWalletProvider(mnemonic, `https://goerli.infura.io/v3/${infuraProjectId}`),
+    //   network_id: 5,       // Goerli's id
+    //   chain_id: 5
+    // }
   },
 
   // Set default mocha options here, use special reporters etc.


### PR DESCRIPTION
I was testing with metacoin box and on `truffle version` and `truffle develop` it errored out looking for the HDWalletProvider. 

It's probably ok to keep those options available and commanded out.
